### PR TITLE
BaSP-TG-95: Fix display modal in entities after edit or create

### DIFF
--- a/src/Components/Admins/Form/index.js
+++ b/src/Components/Admins/Form/index.js
@@ -67,6 +67,7 @@ const Form = (props) => {
 
   const onConfirm = () => {
     id ? dispatch(updateAdmins(adminData, id)) : dispatch(createAdmins(adminData));
+    dispatch(confirmModalClose());
   };
 
   const onCancel = () => {

--- a/src/Components/Employees/Form/index.js
+++ b/src/Components/Employees/Form/index.js
@@ -72,6 +72,7 @@ function Form(props) {
 
   const onConfirm = () => {
     id ? dispatch(updateEmployee(id, formValues)) : dispatch(createEmployee(formValues));
+    dispatch(confirmModalClose());
   };
 
   const onCancel = () => {

--- a/src/Components/Projects/Form/index.js
+++ b/src/Components/Projects/Form/index.js
@@ -76,6 +76,7 @@ const AddProject = (props) => {
     id
       ? dispatch(updateProject(id, projectInput, employeesProject))
       : dispatch(createProject(projectInput, employeesProject));
+    dispatch(confirmModalClose());
   };
 
   useEffect(async () => {

--- a/src/Components/SuperAdmins/Form/Form.js
+++ b/src/Components/SuperAdmins/Form/Form.js
@@ -68,6 +68,7 @@ const Form = (props) => {
     id
       ? dispatch(updateSuperAdmin(superAdminInput, id))
       : dispatch(createSuperAdmin(superAdminInput));
+    dispatch(confirmModalClose());
   };
 
   const onCancel = () => {

--- a/src/Components/Tasks/Form/index.js
+++ b/src/Components/Tasks/Form/index.js
@@ -57,6 +57,7 @@ const TasksForm = (props) => {
 
   const onConfirm = () => {
     id ? dispatch(updateTask(taskInput, id)) : dispatch(createTask(taskInput));
+    dispatch(confirmModalClose());
   };
 
   const onCancel = () => {

--- a/src/Components/TimeSheets/Form/index.js
+++ b/src/Components/TimeSheets/Form/index.js
@@ -100,6 +100,7 @@ const Form = (props) => {
 
   const onConfirm = () => {
     id ? dispatch(updateTimeSheet(timeSheetInput, id)) : dispatch(addTimeSheet(timeSheetInput));
+    dispatch(confirmModalClose());
   };
 
   const onCancel = () => {


### PR DESCRIPTION
When you navigate to another entity after create or edit the modal confirm is displayed! To solve this issue, I add a close modal function after create or edit entities. 

QA:
When you navigate to an entity after create or edit, should not display any modal!