### PR TITLE
BaSP-TG-123: Modify shared component input

### DIFF
--- a/src/Components/Auth/Login/index.js
+++ b/src/Components/Auth/Login/index.js
@@ -5,17 +5,17 @@ import { Schema } from './validations';
 import { useForm } from 'react-hook-form';
 import { useHistory } from 'react-router-dom';
 import { messageModalClose, messageModalOpen } from 'redux/auth/actions';
-import { useState } from 'react';
 
 import ModalMessage from 'Components/Shared/Modal/ModalMessage';
 import Input from 'Components/Shared/Inputs';
 import Buttons from 'Components/Shared/Button';
 import styles from './login.module.css';
+import { useState } from 'react';
 
 const Login = () => {
   const { isLoading, showModalMessage, modalContent } = useSelector((state) => state.auth);
-  const history = useHistory();
   const [showPassword, setShowPassword] = useState(false);
+  const history = useHistory();
   const dispatch = useDispatch();
   const {
     handleSubmit,
@@ -76,27 +76,16 @@ const Login = () => {
               register={register}
               error={errors.email?.message}
             />
-            <div className={styles.inputPassword}>
-              <div className={styles.password}>
-                <Input
-                  label={'Password'}
-                  type={showPassword ? 'text' : 'password'}
-                  name="password"
-                  placeholder={'Password'}
-                  register={register}
-                  error={errors.password?.message}
-                />
-              </div>
-              <img
-                src={
-                  showPassword
-                    ? '/assets/images/eye-icon-png-13.jpg'
-                    : '/assets/images/eyes-closed-eyes.png'
-                }
-                alt="show icon"
-                onClick={passwordShow}
-              ></img>
-            </div>
+            <Input
+              label={'Password'}
+              type={showPassword ? 'text' : 'password'}
+              name="password"
+              placeholder={'Password'}
+              register={register}
+              error={errors.password?.message}
+              show={passwordShow}
+              showState={showPassword}
+            />
             <div>
               <Buttons type="submit" variant="primary" name="Confirm" />
             </div>
@@ -111,7 +100,7 @@ const Login = () => {
           </form>
         ) : (
           <div>
-            <img src="/assets/images/spinner.gif" alt="spinner" />
+            <img className={styles.spinner} src="/assets/images/spinner.gif" alt="spinner" />
           </div>
         )}
       </div>

--- a/src/Components/Auth/Login/index.js
+++ b/src/Components/Auth/Login/index.js
@@ -79,23 +79,16 @@ const Login = () => {
             <div className={styles.inputPassword}>
               <div className={styles.password}>
                 <Input
-                  label={'Password'}
-                  type={showPassword ? 'text' : 'password'}
-                  name="password"
-                  placeholder={'Password'}
                   register={register}
+                  label={'Password'}
+                  name="password"
+                  type={showPassword ? 'text' : 'password'}
                   error={errors.password?.message}
+                  placeholder={'Password'}
+                  show={passwordShow}
+                  showState={showPassword}
                 />
               </div>
-              <img
-                src={
-                  showPassword
-                    ? '/assets/images/eye-icon-png-13.jpg'
-                    : '/assets/images/eyes-closed-eyes.png'
-                }
-                alt="show icon"
-                onClick={passwordShow}
-              ></img>
             </div>
             <div className={styles.buttonContainer}>
               <Buttons type="submit" variant="primary" name="Confirm" />

--- a/src/Components/Auth/Login/login.module.css
+++ b/src/Components/Auth/Login/login.module.css
@@ -49,11 +49,6 @@
     height: 300px;
 }
 
-.inputPassword img{
-    width:30px;
-    height: 30px;
-}
-
 .password {
     width: 100%;
     height: 150px;

--- a/src/Components/Auth/Login/login.module.css
+++ b/src/Components/Auth/Login/login.module.css
@@ -60,7 +60,7 @@ label {
     height: 100%;
 }
 
-.container img {
+.spinner {
     width: 80px;
     height: 80px;
 }

--- a/src/Components/Auth/SignUp/index.js
+++ b/src/Components/Auth/SignUp/index.js
@@ -23,6 +23,14 @@ function SignUp(props) {
     repeatPassword: '',
     phone: ''
   });
+  const [showPassword, setShowPassword] = useState(false);
+  const passwordShow = () => {
+    setShowPassword(!showPassword);
+  };
+  const [showRepeatPassword, setShowRepeatPassword] = useState(false);
+  const repeatPasswordShow = () => {
+    setShowRepeatPassword(!showRepeatPassword);
+  };
 
   const dispatch = useDispatch();
   const { isLoading, modalContent, showModalMessage, showConfirmModal } = useSelector(
@@ -126,23 +134,27 @@ function SignUp(props) {
                 register={register}
                 label={'Password'}
                 name="password"
-                type="password"
+                type={showPassword ? 'text' : 'password'}
                 error={errors.password?.message}
                 placeholder={'Password'}
+                show={passwordShow}
+                showState={showPassword}
               />
               <Input
                 register={register}
                 label={'Repeat Password'}
                 name="repeatPassword"
-                type="password"
+                type={showRepeatPassword ? 'text' : 'password'}
                 error={errors.repeatPassword?.message}
                 placeholder={'Repeat Password'}
+                show={repeatPasswordShow}
+                showState={showRepeatPassword}
               />
               <Input
                 register={register}
                 label={'Phone'}
                 name="phone"
-                type="text"
+                type="password"
                 error={errors.phone?.message}
                 placeholder={'Phone'}
               />

--- a/src/Components/Shared/Inputs/index.js
+++ b/src/Components/Shared/Inputs/index.js
@@ -1,20 +1,44 @@
-import React from 'react';
 import styles from './input.module.css';
 
-const Input = ({ label, disabled, id, register, name, required, placeholder, type, error }) => {
+const Input = ({
+  label,
+  disabled,
+  id,
+  register,
+  name,
+  required,
+  placeholder,
+  type,
+  error,
+  show,
+  showState
+}) => {
   return (
     <div className={styles.inputWrapper}>
       <label className={styles.label}>{label}</label>
-      <input
-        className={`${disabled && styles.disabled} ${styles.input}`}
-        disabled={disabled}
-        id={id}
-        name={name}
-        {...register(name)}
-        required={required}
-        placeholder={placeholder}
-        type={type}
-      />
+      <div className={styles.inputcontainer}>
+        <input
+          className={`${disabled && styles.disabled} ${styles.input}`}
+          disabled={disabled}
+          id={id}
+          name={name}
+          {...register(name)}
+          required={required}
+          placeholder={placeholder}
+          type={type}
+        />
+        {(label === 'Password' || label === 'Repeat Password') && (
+          <img
+            className={styles.eye}
+            onClick={show}
+            src={
+              showState
+                ? '/assets/images/eye-icon-png-13.jpg'
+                : '/assets/images/eyes-closed-eyes.png'
+            }
+          />
+        )}
+      </div>
       {error && <p className={styles.inputError}> {error} </p>}
     </div>
   );

--- a/src/Components/Shared/Inputs/input.module.css
+++ b/src/Components/Shared/Inputs/input.module.css
@@ -1,5 +1,6 @@
 .inputWrapper {
   display: flex;
+  flex-direction: column;
   justify-content: center;
   width: 100%;
 }

--- a/src/Components/Shared/Inputs/input.module.css
+++ b/src/Components/Shared/Inputs/input.module.css
@@ -34,6 +34,17 @@
   outline: none;
 }
 
+.inputcontainer {
+  display: flex;
+  flex-direction: row;
+}
+
+.eye {
+  align-self: center;
+  width: 20px;
+  height: 20px;
+}
+
 .disabled {
   border: 1px solid #ccc;
   color: #ccc;


### PR DESCRIPTION
- Add the img/button on the shared component
- Show only on password type inputs
- Implement on forms that use password input

QA: 
How to test?
To test this ticket you should check the forms that contain password inputs (login form, and sign up form)
A closed eye icon should be visible on the right side of the password or repeat password inputs. If clicked, the icon should change to an open eye.
When the input is filled and you click the eye button you should have two states: closed eye = you should see dots instead of the actual characters- open eye = you should be able to see the characters you wrote on the field.