### PR TITLE
BaSP-TG-136: Change regex in validation

### DIFF
--- a/src/Components/Admins/Form/validatons.js
+++ b/src/Components/Admins/Form/validatons.js
@@ -2,12 +2,12 @@ import Joi from 'joi';
 
 export const Schema = Joi.object({
   name: Joi.string()
-    .pattern(/^[\p{L}]+$/u)
+    .pattern(/^([A-Za-z]+ )+[A-Za-z]+$|^[A-Za-z]+$/u)
     .min(3)
     .required()
     .messages({ 'string.pattern.base': 'Must contain only letters' }),
   lastName: Joi.string()
-    .pattern(/^[\p{L}]+$/u)
+    .pattern(/^([A-Za-z]+ )+[A-Za-z]+$|^[A-Za-z]+$/u)
     .min(3)
     .required()
     .messages({ 'string.pattern.base': 'Must contain only letters' }),

--- a/src/Components/Auth/SignUp/validations.js
+++ b/src/Components/Auth/SignUp/validations.js
@@ -3,7 +3,7 @@ import Joi from 'joi';
 export const employeeSchema = Joi.object({
   name: Joi.string()
     .required()
-    .pattern(/^[\p{L}]+$/u)
+    .pattern(/^([A-Za-z]+ )+[A-Za-z]+$|^[A-Za-z]+$/u)
     .min(3)
     .messages({
       'string.empty': 'Name is required.',
@@ -13,7 +13,7 @@ export const employeeSchema = Joi.object({
     }),
   lastName: Joi.string()
     .required()
-    .pattern(/^[\p{L}]+$/u)
+    .pattern(/^([A-Za-z]+ )+[A-Za-z]+$|^[A-Za-z]+$/u)
     .min(3)
     .messages({
       'string.empty': 'Last Name is required.',

--- a/src/Components/Employees/Form/validations.js
+++ b/src/Components/Employees/Form/validations.js
@@ -3,7 +3,7 @@ import Joi from 'joi';
 export const employeeSchema = Joi.object({
   name: Joi.string()
     .required()
-    .pattern(/^[\p{L}]+$/u)
+    .pattern(/^([A-Za-z]+ )+[A-Za-z]+$|^[A-Za-z]+$/u)
     .min(3)
     .messages({
       'string.empty': 'Name is required.',
@@ -13,7 +13,7 @@ export const employeeSchema = Joi.object({
     }),
   lastName: Joi.string()
     .required()
-    .pattern(/^[\p{L}]+$/u)
+    .pattern(/^([A-Za-z]+ )+[A-Za-z]+$|^[A-Za-z]+$/u)
     .min(3)
     .messages({
       'string.empty': 'Last Name is required.',

--- a/src/Components/Employees/Profile/validations.js
+++ b/src/Components/Employees/Profile/validations.js
@@ -3,7 +3,7 @@ import Joi from 'joi';
 export const employeeSchema = Joi.object({
   name: Joi.string()
     .required()
-    .pattern(/^[\p{L}]+$/u)
+    .pattern(/^([A-Za-z]+ )+[A-Za-z]+$|^[A-Za-z]+$/u)
     .min(3)
     .messages({
       'string.empty': 'Name is required.',
@@ -13,7 +13,7 @@ export const employeeSchema = Joi.object({
     }),
   lastName: Joi.string()
     .required()
-    .pattern(/^[\p{L}]+$/u)
+    .pattern(/^([A-Za-z]+ )+[A-Za-z]+$|^[A-Za-z]+$/u)
     .min(3)
     .messages({
       'string.empty': 'Last Name is required.',

--- a/src/Components/Projects/Form/validations.js
+++ b/src/Components/Projects/Form/validations.js
@@ -18,11 +18,15 @@ const employeeSchema = Joi.object({
 });
 
 export const projectsSchema = Joi.object({
-  name: Joi.string().min(3).required().messages({
-    'string.required': 'Project name is required.',
-    'string.min': 'Project name must have at least 3 characters.',
-    'string.empty': 'Project name is not allowed to be empty.'
-  }),
+  name: Joi.string()
+    .min(3)
+    .required()
+    .pattern(/^([A-Za-z]+ )+[A-Za-z]+$|^[A-Za-z]+$/u)
+    .messages({
+      'string.required': 'Project name is required.',
+      'string.min': 'Project name must have at least 3 characters.',
+      'string.empty': 'Project name is not allowed to be empty.'
+    }),
   description: Joi.string().min(3).required().messages({
     'string.required': 'Project description is required.',
     'string.min': 'Project description must have at least 3 characters.',
@@ -38,7 +42,7 @@ export const projectsSchema = Joi.object({
     'date.empty': 'End date is not allowed to be empty.'
   }),
   clientName: Joi.string()
-    .pattern(/^[\p{L}]+$/u)
+    .pattern(/^([A-Za-z]+ )+[A-Za-z]+$|^[A-Za-z]+$/u)
     .min(3)
     .required()
     .messages({

--- a/src/Components/SuperAdmins/Form/validations.js
+++ b/src/Components/SuperAdmins/Form/validations.js
@@ -3,7 +3,7 @@ import Joi from 'joi';
 export const superAdminsValidationSchema = Joi.object({
   name: Joi.string()
     .min(3)
-    .pattern(/^[\p{L}]+$/u)
+    .pattern(/^([A-Za-z]+ )+[A-Za-z]+$|^[A-Za-z]+$/u)
     .required()
     .messages({
       'string.pattern.base': 'Must contain only letters',
@@ -12,7 +12,7 @@ export const superAdminsValidationSchema = Joi.object({
     }),
   lastName: Joi.string()
     .min(3)
-    .pattern(/^[\p{L}]+$/u)
+    .pattern(/^([A-Za-z]+ )+[A-Za-z]+$|^[A-Za-z]+$/u)
     .required()
     .messages({
       'string.pattern.base': 'Must contain only letters',


### PR DESCRIPTION
Change Regex in entities validations to accept spaces between words.

QA:
In the input's name and last name, only should accept space between words