### PR TITLE
BaSP-TG-142: Super Admin Home

### DIFF
--- a/src/Components/SuperAdmins/Home/home.module.css
+++ b/src/Components/SuperAdmins/Home/home.module.css
@@ -1,0 +1,77 @@
+.projectsWrapper h1 {
+    text-align: center;
+  }
+
+  .spinnerContainer {
+    display: flex;
+    justify-content: center;
+  }
+
+  .spinnerContainer img {
+    width: 80px;
+  }
+
+  .h1 {
+    margin-left: 170px;
+  }
+
+  .container {
+    display: flex;
+    flex-direction: column;
+    margin: auto;
+  }
+
+  .top {
+    display: flex;
+    justify-content: space-between;
+    margin: 30px 0 0 200px;
+  }
+
+  .top div {
+    display: flex;
+    border-bottom: 1px solid #999;
+  }
+
+  .top input {
+    border: none;
+  }
+
+  .table {
+    border-collapse: collapse;
+    caption-side: top;
+    margin: 2em 0 5em 170px;
+    padding: 50px 0;
+    text-align: left;
+  }
+
+  .table caption, td, th {
+    padding: 0.5em 1em;
+  }
+
+  .table th, td {
+    border-bottom: 1px solid #999;
+  }
+
+  .header {
+     text-align: left;
+     font-size: large;
+     color: #FC6225;
+  }
+
+  .header tr th:last-child {
+     text-align: center;
+  }
+
+  .row {
+     white-space: pre-line;
+  }
+
+  .btnContainer {
+     display: flex;
+     justify-content: space-around;
+  }
+
+  .button {
+     background-color: #ffffff00;
+     border: none;
+  }

--- a/src/Components/SuperAdmins/Home/index.js
+++ b/src/Components/SuperAdmins/Home/index.js
@@ -8,6 +8,8 @@ import ModalConfirm from 'Components/Shared/Modal/ModalConfirm';
 import { confirmModalClose, confirmModalOpen } from 'redux/admins/actions';
 import NavBar from '../NavBar';
 import { logout } from 'redux/auth/thunks';
+import ModalMessage from 'Components/Shared/Modal/ModalMessage';
+import { messageModalClose } from 'redux/super-admins/actions';
 
 const SuperAdminsHome = () => {
   const token = sessionStorage.getItem('token');
@@ -17,7 +19,8 @@ const SuperAdminsHome = () => {
     list: adminsList,
     isLoading,
     showConfirmModal,
-    modalContent
+    modalContent,
+    showModalMessage
   } = useSelector((state) => state.admins);
   const [search, setSearch] = useState('');
   const [isDelete, setIsDelete] = useState(false);
@@ -60,6 +63,11 @@ const SuperAdminsHome = () => {
     dispatch(getAdmins(token));
   }, []);
 
+  const modalFunction = () => {
+    modalContent.title.includes('SUCCESS');
+    dispatch(messageModalClose());
+  };
+
   return (
     <>
       <ModalConfirm
@@ -68,6 +76,12 @@ const SuperAdminsHome = () => {
         modalContent={modalContent.content}
         onConfirm={onConfirm}
         onCancel={onCancel}
+      />
+      <ModalMessage
+        show={showModalMessage}
+        modalTitle={modalContent.title}
+        modalContent={modalContent.content}
+        modalFunction={modalFunction}
       />
       <div className={styles.projectsWrapper}>
         {isLoading ? (

--- a/src/Components/SuperAdmins/Home/index.js
+++ b/src/Components/SuperAdmins/Home/index.js
@@ -86,7 +86,7 @@ const SuperAdminsHome = () => {
                     ></input>
                   </div>
                   <div>
-                    <Link to={`super-admins/admins`}>
+                    <Link to={`admins`}>
                       <button className={styles.button}>
                         <img src="/assets/images/add.svg" alt="add" />
                       </button>

--- a/src/Components/SuperAdmins/Home/index.js
+++ b/src/Components/SuperAdmins/Home/index.js
@@ -47,15 +47,8 @@ const SuperAdminsHome = () => {
     if (modalContent.content.includes('logout')) {
       dispatch(logout());
     } else {
-      setValues({
-        name: admin.name,
-        lastName: admin.lastName,
-        email: admin.email,
-        password: admin.password,
-        firebaseUid: admin.firebaseUid,
-        isDeleted: true
-      });
-      dispatch(updateAdmins(values, itemId, token));
+      console.log(itemId);
+      dispatch(deleteAdmins(itemId, token));
     }
     dispatch(confirmModalClose());
   };
@@ -119,8 +112,7 @@ const SuperAdminsHome = () => {
                     {results.map((item) => {
                       const id = item._id;
                       const openModal = () => {
-                        const admin = adminsList.filter((admin) => admin._id === id)[0];
-                        setAdmin(admin);
+                        setItemId(id);
                         const content = 'Are you sure you want to delete this Admin?';
                         dispatch(confirmModalOpen(content));
                       };

--- a/src/Components/SuperAdmins/Home/index.js
+++ b/src/Components/SuperAdmins/Home/index.js
@@ -1,7 +1,145 @@
+/* eslint-disable no-unused-vars */
+import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import styles from './home.module.css';
+import { deleteAdmins, getAdmins } from 'redux/admins/thunks';
+import { Link } from 'react-router-dom';
+import ModalConfirm from 'Components/Shared/Modal/ModalConfirm';
+import { confirmModalClose, confirmModalOpen } from 'redux/auth/actions';
+
 const SuperAdminsHome = () => {
+  const token = sessionStorage.getItem('token');
+  const dispatch = useDispatch();
+  const {
+    list: adminsList,
+    isLoading,
+    showConfirmModal,
+    modalContent
+  } = useSelector((state) => state.admins);
+  const [search, setSearch] = useState('');
+
+  const headers = ['Name', 'Last Name', 'Email'];
+  const dataValues = ['name', 'lastName', 'email'];
+
+  const results = !search
+    ? adminsList
+    : adminsList.filter(
+        (value) =>
+          value.name?.toLowerCase().includes(search.toLocaleLowerCase()) ||
+          value.lastName?.toLowerCase().includes(search.toLocaleLowerCase()) ||
+          value.email?.toLowerCase().includes(search.toLocaleLowerCase()) ||
+          value.description?.toLowerCase().includes(search.toLocaleLowerCase()) ||
+          value.phone?.toLowerCase().includes(search.toLocaleLowerCase()) ||
+          value.clientName?.toLowerCase().includes(search.toLocaleLowerCase()) ||
+          value.startDate?.toLowerCase().includes(search.toLocaleLowerCase()) ||
+          value.endDate?.toLowerCase().includes(search.toLocaleLowerCase()) ||
+          value.employees?.toLowerCase().includes(search.toLocaleLowerCase())
+      );
+
+  const [itemId, setItemId] = useState(null);
+  const modalWrapper = (id) => {
+    const content = 'Are you sure you want to delete this Admin?';
+    setItemId(id);
+    dispatch(confirmModalOpen(content));
+  };
+  const onConfirm = () => {
+    dispatch(deleteAdmins(itemId));
+    dispatch(confirmModalClose());
+  };
+  const onCancel = () => {
+    dispatch(confirmModalClose());
+  };
+
+  useEffect(() => {
+    dispatch(getAdmins(token));
+  }, []);
+
   return (
     <>
-      <div>SuperAdmins HOME</div>
+      <ModalConfirm
+        show={showConfirmModal}
+        modalTitle={modalContent.title}
+        modalContent={modalContent.content}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />
+      <div className={styles.projectsWrapper}>
+        {isLoading ? (
+          <div className={styles.spinnerContainer}>
+            <img src="/assets/images/spinner.gif" alt="spinner" />
+          </div>
+        ) : (
+          <>
+            {adminsList.length == 0 ? (
+              <h1 className={styles.h1}>Admins not found.</h1>
+            ) : (
+              <div className={styles.container}>
+                <div className={styles.top}>
+                  <div className={styles.searchBox}>
+                    <img src="/assets/images/lens.svg" alt="update" />
+                    <input
+                      type="search"
+                      placeholder="Search.."
+                      className="search"
+                      value={search}
+                      onChange={(e) => setSearch(e.target.value)}
+                    ></input>
+                  </div>
+                  <div>
+                    <Link to={`super-admins/admins`}>
+                      <button className={styles.button}>
+                        <img src="/assets/images/add.svg" alt="add" />
+                      </button>
+                    </Link>
+                  </div>
+                </div>
+                <table className={styles.table}>
+                  <thead className={styles.header}>
+                    <tr>
+                      {headers.map((header, index) => {
+                        return <th key={index}>{header}</th>;
+                      })}
+                      <th key={headers.length - 1}>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {results.map((item) => {
+                      const openModal = () => {
+                        modalWrapper(item._id);
+                      };
+                      return (
+                        <>
+                          <tr key={item._id} className={styles.row}>
+                            {dataValues.map((value, index) => {
+                              return (
+                                <>
+                                  <td key={index}>{item[value]}</td>
+                                </>
+                              );
+                            })}
+                            <td key={item._id}>
+                              <div className={styles.btnContainer}>
+                                <Link to={`super-admins/admins/${item._id}`}>
+                                  <button className={styles.button}>
+                                    <img src="/assets/images/edit.svg" alt="edit" />
+                                  </button>
+                                </Link>
+                                <button onClick={openModal} className={styles.button}>
+                                  <img src="/assets/images/trash.svg" alt="delete" />
+                                </button>
+                              </div>
+                            </td>
+                          </tr>
+                        </>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </>
+        )}
+      </div>
     </>
   );
 };

--- a/src/Components/SuperAdmins/Home/index.js
+++ b/src/Components/SuperAdmins/Home/index.js
@@ -119,7 +119,7 @@ const SuperAdminsHome = () => {
                             })}
                             <td key={item._id}>
                               <div className={styles.btnContainer}>
-                                <Link to={`super-admins/admins/${item._id}`}>
+                                <Link to={`admins/${item._id}`}>
                                   <button className={styles.button}>
                                     <img src="/assets/images/edit.svg" alt="edit" />
                                   </button>

--- a/src/Components/SuperAdmins/Home/index.js
+++ b/src/Components/SuperAdmins/Home/index.js
@@ -50,7 +50,6 @@ const SuperAdminsHome = () => {
     if (modalContent.content.includes('logout')) {
       dispatch(logout());
     } else {
-      console.log(itemId);
       dispatch(deleteAdmins(itemId, token));
     }
     dispatch(confirmModalClose());

--- a/src/Components/SuperAdmins/NavBar/index.js
+++ b/src/Components/SuperAdmins/NavBar/index.js
@@ -1,40 +1,22 @@
-import ModalConfirm from 'Components/Shared/Modal/ModalConfirm';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { logout } from 'redux/auth/thunks';
-import { confirmModalClose, confirmModalOpen } from 'redux/super-admins/actions';
+import { confirmModalOpen } from 'redux/super-admins/actions';
 import styles from './navbar.module.css';
 
 const NavBar = () => {
   const dispatch = useDispatch();
-  const { modalContent, showConfirmModal } = useSelector((state) => state.auth);
-  const onConfirm = () => {
-    dispatch(logout());
-    dispatch(confirmModalClose());
-  };
 
   const onSubmit = () => {
-    const content = `Are you sure you want to logout?`;
+    const content = 'Are you sure you want to logout?';
     dispatch(confirmModalOpen(content));
-  };
-
-  const onCancel = () => {
-    dispatch(confirmModalClose());
   };
 
   return (
     <>
-      <ModalConfirm
-        show={showConfirmModal}
-        modalTitle={modalContent.title}
-        modalContent={modalContent.content}
-        onConfirm={onConfirm}
-        onCancel={onCancel}
-      />
       <div className={styles.container}>
         <ul className={styles.nav}>
           <li>
-            <Link to="/super-admins/">Admins</Link>
+            <Link to="/super-admins">Admins</Link>
           </li>
           <li>
             <Link to="/super-admins/profile">Profile</Link>

--- a/src/Components/SuperAdmins/NavBar/index.js
+++ b/src/Components/SuperAdmins/NavBar/index.js
@@ -1,0 +1,51 @@
+import ModalConfirm from 'Components/Shared/Modal/ModalConfirm';
+import { useDispatch, useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { logout } from 'redux/auth/thunks';
+import { confirmModalClose, confirmModalOpen } from 'redux/super-admins/actions';
+import styles from './navbar.module.css';
+
+const NavBar = () => {
+  const dispatch = useDispatch();
+  const { modalContent, showConfirmModal } = useSelector((state) => state.auth);
+  const onConfirm = () => {
+    dispatch(logout());
+    dispatch(confirmModalClose());
+  };
+
+  const onSubmit = () => {
+    const content = `Are you sure you want to logout?`;
+    dispatch(confirmModalOpen(content));
+  };
+
+  const onCancel = () => {
+    dispatch(confirmModalClose());
+  };
+
+  return (
+    <>
+      <ModalConfirm
+        show={showConfirmModal}
+        modalTitle={modalContent.title}
+        modalContent={modalContent.content}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />
+      <div className={styles.container}>
+        <ul className={styles.nav}>
+          <li>
+            <Link to="/super-admins/">Admins</Link>
+          </li>
+          <li>
+            <Link to="/super-admins/profile">Profile</Link>
+          </li>
+          <li>
+            <Link onClick={onSubmit}>Logout</Link>
+          </li>
+        </ul>
+      </div>
+    </>
+  );
+};
+
+export default NavBar;

--- a/src/Components/SuperAdmins/NavBar/navbar.module.css
+++ b/src/Components/SuperAdmins/NavBar/navbar.module.css
@@ -1,0 +1,9 @@
+.container {
+    background-color: gray;
+}
+
+.nav {
+    display: flex;
+    justify-content: space-between;
+    width: 30%;
+}

--- a/src/redux/admins/reducer.js
+++ b/src/redux/admins/reducer.js
@@ -80,7 +80,7 @@ const adminsReducer = (state = INITIAL_STATE, action) => {
         showConfirmModal: false,
         modalContent: {
           title: 'SUCCESS',
-          content: `Admins Successfully CREATED`
+          content: 'Admins Successfully CREATED'
         },
         showModalMessage: true
       };
@@ -137,7 +137,7 @@ const adminsReducer = (state = INITIAL_STATE, action) => {
         list: [...state.list.filter((item) => item._id !== action.payload)],
         modalContent: {
           title: 'SUCCESS',
-          content: `Admins with id ${action.payload} successfully deleted`
+          content: 'Account Successfully DELETED'
         },
         showModalMessage: true
       };

--- a/src/redux/admins/thunks.js
+++ b/src/redux/admins/thunks.js
@@ -31,11 +31,13 @@ export const getAdmins = (token) => {
   };
 };
 
-export const getByIdAdmin = (id) => {
+export const getByIdAdmin = (id, token) => {
   return async (dispatch) => {
     dispatch(getByIdAdminsPending());
     try {
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/admin/${id}`);
+      const response = await fetch(`${process.env.REACT_APP_API_URL}/admin/${id}`, {
+        headers: { token }
+      });
       const data = await response.json();
       if (response.status == 200) {
         dispatch(getByIdAdminsSuccess(data.data));
@@ -79,15 +81,15 @@ export const createAdmins = (input) => {
   };
 };
 
-export const updateAdmins = (input, id) => {
+export const updateAdmins = (input, id, token) => {
   return async (dispatch) => {
     dispatch(updateAdminsPending());
     try {
       const response = await fetch(`${process.env.REACT_APP_API_URL}/admin/${id}`, {
         method: 'PUT',
         headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json'
+          token,
+          'Content-type': 'application/json; charset=UTF-8'
         },
         body: JSON.stringify({
           name: input.name,
@@ -109,12 +111,16 @@ export const updateAdmins = (input, id) => {
   };
 };
 
-export const deleteAdmins = (id) => {
+export const deleteAdmins = (id, token) => {
   return async (dispatch) => {
     dispatch(deleteAdminsPending());
     try {
       const response = await fetch(`${process.env.REACT_APP_API_URL}/admin/${id}`, {
-        method: 'DELETE'
+        method: 'DELETE',
+        headers: {
+          token,
+          'Content-type': 'application/json; charset=UTF-8'
+        }
       });
       if (response.status == 204) {
         dispatch(deleteAdminsSuccess(id));

--- a/src/redux/admins/thunks.js
+++ b/src/redux/admins/thunks.js
@@ -16,11 +16,13 @@ import {
   deleteAdminsError
 } from './actions';
 
-export const getAdmins = () => {
+export const getAdmins = (token) => {
   return async (dispatch) => {
     dispatch(getAdminsPending());
     try {
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/admin`);
+      const response = await fetch(`${process.env.REACT_APP_API_URL}/admin`, {
+        headers: { token }
+      });
       const json = await response.json();
       dispatch(getAdminsSuccess(json.data));
     } catch (error) {

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -26,7 +26,7 @@ const Layout = () => {
       <div className={styles.container}>
         <Switch>
           <Route path="/auth" component={AuthRoutes} />
-          <PrivateRoute exact path="/admins" role="ADMIN" component={AdminRoutes} />
+          <PrivateRoute path="/admins" role="ADMIN" component={AdminRoutes} />
           <PrivateRoute path="/super-admins" role="SUPER_ADMIN" component={SuperAdminRoutes} />
           <PrivateRoute path="/employees" role="EMPLOYEE" component={EmployeeRoutes} />
           <Redirect to="/auth" />

--- a/src/routes/superAdmins.js
+++ b/src/routes/superAdmins.js
@@ -1,3 +1,4 @@
+import NavBar from 'Components/SuperAdmins/NavBar';
 import React, { lazy } from 'react';
 import { Suspense } from 'react';
 import { useRouteMatch, Route, Switch, BrowserRouter } from 'react-router-dom';
@@ -17,6 +18,7 @@ const SuperAdminRoutes = () => {
           </div>
         }
       >
+        <NavBar />
         <Switch>
           <Route exact path={`${url}/`} component={SuperAdminsHome} />
           <Route exact path={`${url}/admins`} component={AdminForm} />


### PR DESCRIPTION
- In Home add admins Table
- Create Admins only button
- Edit Admins only button
- Add search shared component
- Delete Admin button and functionality (soft delete)
- When click create admin button in the table, redirect to create Admin form
- When click edit admin button in the table, redirect to edit Admin form

QA:
How to test?:
Log in as a Super Admin (email: oclacep@wikimedia.org, password: prueba1234)
When logged you should se a nav bar (temporary)
In the Home page you should see a list of Admins
The "+" button redirects you to a form page (empty)
The "edit" buttons should redirect you to the same form, but the path should have the id of the admin to edit.
The "delete" button should open a modal, on cancel modal will close, on confirm a message modal will appear with the error/success message, then will close.
Note: The nav bar is temporaryand just to use on the test of the PRs, any bad function on navigation should be ignored.